### PR TITLE
remove deprecated codeclimate-test-reporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,9 @@ cache: bundler
 rvm:
 - 2.5.7
 - 2.6.5
+before_script:
+- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+- chmod +x ./cc-test-reporter
+- ./cc-test-reporter before-build
+after_script:
+- ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/manageiq-ssh-util.gemspec
+++ b/manageiq-ssh-util.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.add_dependency "net-ssh",  "~> 4.2"
   s.add_dependency "net-sftp", "~> 2.1"
 
-  s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "manageiq-style"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
```
Post-install message from codeclimate-test-reporter:

  Code Climate's codeclimate-test-reporter gem has been deprecated in favor of
  our language-agnostic unified test reporter. The new test reporter is faster,
  distributed as a static binary so dependency conflicts never occur, and
  supports parallelized CI builds & multi-language CI configurations.

  Please visit https://docs.codeclimate.com/v1.0/docs/configuring-test-coverage
  for help setting up your CI process with our new test reporter.
```

it depends on the addition of the token re: https://github.com/ManageIQ/azure-armrest/pull/403#issuecomment-754050779

@miq-bot add_label dependencies, test 
@miq-bot assign @Fryguy 