### PR TITLE
[WIP] upgrade net::ssh version

### DIFF
--- a/manageiq-ssh-util.gemspec
+++ b/manageiq-ssh-util.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md", "CHANGELOG.md"]
 
   s.add_dependency "activesupport"
-  s.add_dependency "net-ssh",  "~> 4.2"
+  s.add_dependency "net-ssh",  "~> 6.1"
   s.add_dependency "net-sftp", "~> 2.1"
 
   s.add_development_dependency "manageiq-style"


### PR DESCRIPTION
Upgrade net ssh version to a version that properly handles remote trust

Currently, we require a user to manually add it before running commands like `fix_auth --fetch-key`:

```sh
eval `ssh-agent -s`
ssh-add
```

This is a common scenario and not a hack. But it does require a certain level of knowledge of linux and ssh that may be beyond most users.

With the upgrade of the net::ssh gem, the admin no longer needs to manage the ssh trust chain.

@bdunne or @Fryguy : I am not able to judge the danger of this change. And requiring the user to properly setup their trust chain may be valid. The only breaking changes I saw around this is requiring a different gem dependency.

I did not test this. I could not get the appliance console cli to pickup this change.
Does look like we have a number of gems that depend upon 4.2, not sure if this is pegged because of an incompatibility or if it has bigger reasons.

addresses https://github.com/ManageIQ/manageiq/issues/20091
fixed https://bugzilla.redhat.com/show_bug.cgi?id=1824306

